### PR TITLE
Add disclaimer for renaming "facets"

### DIFF
--- a/_includes/featured-accordion.html
+++ b/_includes/featured-accordion.html
@@ -23,6 +23,8 @@
                         How to Index with Search.gov
                     {% when "manage-account" %}
                         Create or Edit Your User Account
+                    {% when "facet-renaming" %}
+                        Future Feature: Faceted Search
                     {% else %}
                         Related Content
                 {% endcase %}
@@ -93,6 +95,8 @@
                         For sites switching from Bing: When you give us the green light to switch to the new index, there is no action needed on your part other than the approval. We will change a setting in our back end, which will point your existing search site’s web results module to our index, and the change is effective immediately. All other elements of your search site remain the same: search features, branding, etc.
                     {% when "manage-account" %}
                         <a href="{{ site.baseurl }}/get-started/account.html#sign-up">Register for a new account</a>, <a href="{{ site.baseurl }}/get-started/account.html#login">log in</a> to make changes to an existing account, or <a href="{{ site.baseurl }}/support.html">find information</a> on how to resolve issues accessing your account.
+                    {% when "facet-renaming" %}
+                        <i><strong>Note:</strong> We are releasing a true faceted search feature in early 2023. At that point, we will be renaming the existing search facet features to avoid confusion.</i>
                     {% else %}
                 {% endcase %}
         {% if include.accordion %}

--- a/admin-center/content/collections.md
+++ b/admin-center/content/collections.md
@@ -26,6 +26,8 @@ Paths that are three or more subfolders deep may not return results immediately.
 
 ## Step 2. Opt to Show As a Facet
 
+{% include featured-accordion.html content="facet-renaming" accordion=false %}
+
 Click on the [Display Overview]({{ site.baseurl }}/admin-center/display/display-overview.html) page. Turn on your collection to allow searchers to see it as a search facet in the navigation bar above the search box on the results page (in the desktop view), or in the search menu (on smaller screens).
 
 ## Step 3. Check Your Search Results Page

--- a/admin-center/content/rss.md
+++ b/admin-center/content/rss.md
@@ -88,6 +88,8 @@ If you opted to show your RSS feed(s) as a module, searchers will see inline new
 
 ### Facet
 
+{% include featured-accordion.html content="facet-renaming" accordion=false %}
+
 If you opted to show your RSS feed(s) as a facet, searchers can narrow their results to see only RSS-based content by clicking on the facet.
 
 Within the RSS-based results, searchers can opt to limit results to the last hour, day, week, month, or year, or they can set a custom date range. They also can sort results in descending order by relevance (best match first) or date (most recent first).

--- a/admin-center/content/youtube.md
+++ b/admin-center/content/youtube.md
@@ -30,6 +30,8 @@ We'll show the videos by default. You can toggle the settings for showing your v
 
 **Facet**
 
+{% include featured-accordion.html content="facet-renaming" accordion=false %}
+
 ![Videos Facet on DigitalGov.gov]({{ site.url }}/assets/img/site/Videos-Facet.png "Videos Facet on DigitalGov.gov"){:height="95%" width="95%"}
 
 **Inline Module**

--- a/admin-center/display/display-overview.md
+++ b/admin-center/display/display-overview.md
@@ -15,8 +15,9 @@ Find it in the Admin Center: [Search.gov Home]({{ site.baseurl }}/index.html) > 
 Related resource: [Comparison of our hosted search results page and our results API]({{ site.baseurl }}/admin-center/display/hosted-vs-api-results.html)
 
 ## Facets
-
 > These features are only available on the hosted search results page.
+
+{% include featured-accordion.html content="facet-renaming" accordion=false %}
 
 **Label.** By default, we use the label 'Search' for your facets. Enter a label in the label field if you'd like something other than this default. Keep your label consistent with the options you're listing and under 15 characters.
 

--- a/admin-center/display/display-overview.md
+++ b/admin-center/display/display-overview.md
@@ -15,9 +15,9 @@ Find it in the Admin Center: [Search.gov Home]({{ site.baseurl }}/index.html) > 
 Related resource: [Comparison of our hosted search results page and our results API]({{ site.baseurl }}/admin-center/display/hosted-vs-api-results.html)
 
 ## Facets
-> These features are only available on the hosted search results page.
-
 {% include featured-accordion.html content="facet-renaming" accordion=false %}
+
+These features are only available on the hosted search results page.
 
 **Label.** By default, we use the label 'Search' for your facets. Enter a label in the label field if you'd like something other than this default. Keep your label consistent with the options you're listing and under 15 characters.
 
@@ -32,7 +32,7 @@ Type over the text in the Name field to edit a facet's display name. Keep each n
 
 ## Modules
 
-> These options control what types of search results are returned, and apply to both the hosted search results page and the search results API.
+These options control what types of search results are returned, and apply to both the hosted search results page and the search results API.
 
 **On/Off Options for Modules.** Turn on a module to allow searchers to see inline, contextually relevant results for selected content sources based on keyword matches with relevant queries. There are eight types of modules.
 
@@ -55,7 +55,7 @@ Type over the text in the Name field to edit a facet's display name. Keep each n
 
 ## Related Sites
 
-> This feature is only available on the hosted search results page.
+This feature is only available on the hosted search results page.
 
 Help visitors find content relevant to their search query that resides on other websites, such as the site for your parent organization or your Spanish-language site. When searchers click on the link to the related site, they see search results for their query on the related site.
 

--- a/get-started/go-live.md
+++ b/get-started/go-live.md
@@ -29,6 +29,8 @@ Your pre-launch checklist will be unique to your agency's workflow, requirements
 
 <i class="icon-check"></i> **6. Have you told us what to show on your results page?** Turn on (or off) the inline modules and facets that you want to appear on your search results page. You can change the default settings on the [Display Overview]({{ site.baseurl }}/admin-center/display/display-overview.html) page in the Admin Center.
 
+{% include featured-accordion.html content="facet-renaming" accordion=false %}
+
 ## Connect Your Site to Search.gov
 
 Most agencies add these two [snippets of code]({{ site.baseurl }}/admin-center/activate/code.html) to the template(s) in their websites or content management systems (rather than adding them to individual pages).


### PR DESCRIPTION
## Summary
Because we will be releasing a faceted search interface, we need to rethink how we refer to "facets", meaning segmented views of search content, in our documentation. For now, we are adding a disclaimer that this naming will change in the future.

I've done this by creating a snippet in the `featured-accordion.html` includes file so we can reuse the text in several places.

You can see this in action in a few pages:

- https://cg-a72b65a7-73f0-4859-a1d7-dc953cf6ade8.sites.pages.cloud.gov/preview/gsa/search-gov-website/faceted-search-renaming/admin-center/display/display-overview.html
- https://cg-a72b65a7-73f0-4859-a1d7-dc953cf6ade8.sites.pages.cloud.gov/preview/gsa/search-gov-website/faceted-search-renaming/admin-center/content/collections.html
- https://cg-a72b65a7-73f0-4859-a1d7-dc953cf6ade8.sites.pages.cloud.gov/preview/gsa/search-gov-website/faceted-search-renaming/admin-center/content/rss.html

## PR Checklist
- [x] Test Cloud.gov Pages preview link for your branch for functionality - make sure all links and buttons work, javascript works as intended, and updates display as expected
- [x] Conduct a HemingwayApp review of the content for plain language. Request plain language review in #helpwanted if needed before merging this PR
- [N/A] Conduct a Lighthouse Audit via Chrome Developer Tools. Identify any issues that must be addressed before merging, and fix
- [x] Ensure no non-public information is published in the commit messages
